### PR TITLE
Add GitHub links to the DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,3 +23,5 @@ RoxygenNote: 6.1.1
 Suggests:
   knitr,
   rmarkdown
+URL: https://github.com/javierluraschi/nomnoml
+BugReports: https://github.com/javierluraschi/nomnoml/issues, https://github.com/skanaar/nomnoml/issues

--- a/README.Rmd
+++ b/README.Rmd
@@ -192,4 +192,4 @@ Available modifiers are
 
 ## Contributing
 
-Please reffer to [github.com/skanaar/nomnoml](https://github.com/skanaar/nomnoml).
+Please refer to [github.com/skanaar/nomnoml](https://github.com/skanaar/nomnoml).

--- a/README.md
+++ b/README.md
@@ -178,5 +178,5 @@ Available modifiers are
 
 ## Contributing
 
-Please reffer to
+Please refer to
 [github.com/skanaar/nomnoml](https://github.com/skanaar/nomnoml).


### PR DESCRIPTION
I added these with `usethis::use_github_links()`, which I always forget to do on my new repos as well :)