### PR TITLE
Allow Unicode escapes to be used in nomnoml code chunks.

### DIFF
--- a/R/knit.R
+++ b/R/knit.R
@@ -34,7 +34,12 @@ knit_nomnoml <- function (options) {
   knit_print <- get("knit_print", envir = asNamespace("knitr"))
   engine_output <- get("engine_output", envir = asNamespace("knitr"))
   code <- paste(options$code, collapse = "\n")
-  
+  if (isTRUE(options$escape)) 
+    usecode <- code
+  else {
+    usecode <- gsub("'", "\\\\'", code)
+    usecode <- eval(parse(text = paste0("'", usecode, "'")))
+  }
   widget_width <- options$width
   widget_height <- options$height
   fixed_image <- FALSE
@@ -59,12 +64,12 @@ knit_nomnoml <- function (options) {
   if ("reactive" %in% class(options$data)) {
     widget <- renderNomnoml({
       nomnoml(
-        code
+        usecode
       )
     })
   } else {
     widget <- nomnoml(
-      code = code,
+      code = usecode,
       width = widget_width,
       height = widget_height
     )

--- a/tests/testthat/example_knitr.Rmd
+++ b/tests/testthat/example_knitr.Rmd
@@ -20,3 +20,15 @@ library(nomnoml)
 ```{nomnoml two, width="250px", height="75px", echo=FALSE, svg = TRUE}
 [Hello]-[World!]
 ```
+
+Add Greek alpha as label:
+
+```{nomnoml three, width="250px", height="75px", echo=FALSE, svg = TRUE}
+[Hello]-\u03b1[World!]
+```
+
+Show the backslash:
+
+```{nomnoml four, width="250px", height="75px", echo=FALSE, svg = TRUE, escape = TRUE}
+[Hello]-\A[World!]
+```

--- a/vignettes/markdown.Rmd
+++ b/vignettes/markdown.Rmd
@@ -74,3 +74,16 @@ And the same diagram, this time with specified size:
   [Component] <:- [ConcreteComponent]
 ]
 ```
+
+Unicode escapes (using R conventions) can be used 
+in code chunks.  
+
+```{nomnoml echo=TRUE, svg = TRUE, height = "1in"}
+[Hello]-\u03b1[World!]
+```
+
+To include backslashes in labels, specify `escape = TRUE`:
+
+```{nomnoml echo=TRUE, svg = TRUE, height = "1in", escape = TRUE}
+[Hello]-\A[World!]
+```


### PR DESCRIPTION
This SO question:  https://stackoverflow.com/q/72271331/2554330 had a user who wanted to include Greek letters specified using Unicode escapes in labels in a nomnoml diagram.

This PR allows this, by parsing the code in the nomnoml code chunk to get R to process Unicode chars, unless `escape = TRUE` is used as a chunk option, in which case the backslash will be passed through to the widget, where it will be displayed without processing.

The name of the option matches the name used in `knitr::kable`, but the default is the opposite here:  using Unicode escapes seems like a reasonable thing to do, whereas wanting backslashes in the output seems uncommon.